### PR TITLE
Recursive config directory; customizable date format

### DIFF
--- a/scripts/dirvish-report.sh
+++ b/scripts/dirvish-report.sh
@@ -35,10 +35,13 @@ get_dirvish_option() {
 # SETUP
 #
 
+DIR_DATE_FMT=$(get_dirvish_option image-default)
+: ${DIR_DATE_FMT:=%Y%m%d}
+
 if [ ! -z "$1" ]; then
   DATE="$1"
 else
-  DATE=$(date +%Y%m%d)
+  DATE=$(date +${DIR_DATE_FMT})
 fi
 HUMAN_READABLE_DATE=$(date -ud "$DATE" +'%Y-%m-%d')
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo ">> copy config"
-cp /config/* /etc/dirvish/
+cp -r /config/* /etc/dirvish
 
 echo ">> fix postfix"
 postconf -e "maillog_file = /dev/stdout"


### PR DESCRIPTION
The first change allows subdirectories in the dirvish configuration directory. I want `master.conf` to be world-readable, but dirvish's private ssh key should be hidden in a `ssh` subdirectory.

The second change tells `dirvish-report.sh` to read the `image-default` option to get the format of the backup directory.