### PR TITLE
Rewrite get_dirvish_option to work with single-line options as well.

### DIFF
--- a/scripts/dirvish-report.sh
+++ b/scripts/dirvish-report.sh
@@ -28,7 +28,29 @@ human_readable_bytes() {
 
 get_dirvish_option() {
   option=$1
-  cat /etc/dirvish/master.conf | sed 's/#.*//g' | sed -n '/'"$option"':/,/^\w/p' | sed -e '/^\w/d' -e '/^$/d' -e 's/[ \t][ \t]*//g' -e 's/[ \t][ \t].*$//g' | tr '\n' ' '
+  cat /etc/dirvish/master.conf |
+      sed -n '
+	s/^#.*//;	# Strip comments
+	/^\s/{ H; b }	# Indented line: append to hold, and start next cycle
+	/^\w/ba		# A word means option assignment. Process it
+	b		# If we get this far, start next cycle.
+	:a		# Label a: we have just seen a word. So now
+			# the holding space contains the previous
+			# "option: value" line, as well as any space-indented
+			# lines that came after that.
+			# Now we need to look at holding space and see
+			# if it has the option we want.
+	x		# Swap hold and pattern
+	/^'"${option}"'/{
+		s/^\(-\|\w\)\+:\s*//	# Remove the option and colon
+		s/\n\+/ /g		# Translate newlines to spaces
+		p			# Print the option value
+		q			# And quit
+	}
+	$ba		# If the option we want is at end of file,
+			# then we just stashed it in holding space. So
+			# swap again, and redo the processing.
+	'
 }
 
 #


### PR DESCRIPTION
The current version of get_dirvish_option only works with multi-line options like

    bank:
            /backups/nas-system
            /backups/data

This patch makes it work with single-line options as well, like

    image-default: %Y%m%d

The sed script is complicated, yes, but heavily commented.